### PR TITLE
Fix typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -259,7 +259,7 @@ if following edits were applied to the definition of {{DOMTokenList}}.
     </blockquote>
 
 
-Selecting a custom element with a speicfic state {#selecting}
+Selecting a custom element with a specific state {#selecting}
 ============================
 
 The <dfn>custom state pseudo class</dfn> '':--foo'' is a [=pseudo-class=],


### PR DESCRIPTION
s/speicfic/specific


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Malvoz/custom-state-pseudo-class/pull/12.html" title="Last updated on Dec 7, 2020, 3:34 PM UTC (201b69b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/custom-state-pseudo-class/12/74a610c...Malvoz:201b69b.html" title="Last updated on Dec 7, 2020, 3:34 PM UTC (201b69b)">Diff</a>