### PR TITLE
Trim the editors to just Kent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,8 +6,8 @@ Status: CG-DRAFT
 Group: WICG
 ED: https://wicg.github.io/custom-state-pseudo-class/
 Editor: Kent Tamura, Google https://www.google.com/, tkent@google.com
-Editor: Rakina Zata Amni, Google https://www.google.com/, rakina@google.com
-Editor: Domenic Denicola, Google https://www.google.com/, d@domenic.me, https://domenic.me/
+Former Editor: Rakina Zata Amni, Google https://www.google.com/, rakina@google.com
+Former Editor: Domenic Denicola, Google https://www.google.com/, d@domenic.me, https://domenic.me/
 Repository: https://github.com/WICG/custom-state-pseudo-class/
 Abstract: This specification defines a way to expose custom element's internal
     states, and defines the <a>custom state pseudo class</a> '':--foo'' matching


### PR DESCRIPTION
This is tentative; feel free to tell me I've got the wrong set. I'm trying to make sure that the listed editors are the people actively handling any issues that come up.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/custom-state-pseudo-class/pull/14.html" title="Last updated on Apr 27, 2022, 8:34 PM UTC (bb8b2a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/custom-state-pseudo-class/14/6f9926a...jyasskin:bb8b2a6.html" title="Last updated on Apr 27, 2022, 8:34 PM UTC (bb8b2a6)">Diff</a>